### PR TITLE
Fix oplogSize for 32bit-systems.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,7 +12,14 @@ default['mongodb']['enable_rest'] = true
 default['mongodb']['enable_jsonp'] = false
 default['mongodb']['enable_nojournal'] = false
 default['mongodb']['enable_directoryperdb'] = true
-default['mongodb']['oplogSize'] = node['kernel']['machine'].index("x86_64") ? 5120 : 1000
+
+case node['kernel']['machine']
+when 'i386', 'i686'
+  default['mongodb']['oplogSize'] = 1000
+else
+  default['mongodb']['oplogSize'] = 5120  
+end
+
 
 default['mongodb']['base_dir'] = '/data/mongodb'
 default['mongodb']['etc_dir'] = File.join(node['mongodb']['base_dir'], "etc")
@@ -48,7 +55,13 @@ default['mongodb']['config']['enable_rest'] = true
 default['mongodb']['config']['enable_jsonp'] = false
 default['mongodb']['config']['enable_nojournal'] = false
 default['mongodb']['config']['enable_directoryperdb'] = true
-default['mongodb']['config']['oplogSize'] = node['kernel']['machine'].index("x86_64") ? 5120 : 1000
+
+case node['kernel']['machine']
+when 'i386', 'i686'
+  default['mongodb']['config']['oplogSize'] = 1000
+else
+  default['mongodb']['config']['oplogSize'] = 5120  
+end
 
 
 ## for mongos

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,7 +12,7 @@ default['mongodb']['enable_rest'] = true
 default['mongodb']['enable_jsonp'] = false
 default['mongodb']['enable_nojournal'] = false
 default['mongodb']['enable_directoryperdb'] = true
-default['mongodb']['oplogSize'] = 5120
+default['mongodb']['oplogSize'] = node['kernel']['machine'].index("x86_64") ? 5120 : 1000
 
 default['mongodb']['base_dir'] = '/data/mongodb'
 default['mongodb']['etc_dir'] = File.join(node['mongodb']['base_dir'], "etc")
@@ -48,7 +48,7 @@ default['mongodb']['config']['enable_rest'] = true
 default['mongodb']['config']['enable_jsonp'] = false
 default['mongodb']['config']['enable_nojournal'] = false
 default['mongodb']['config']['enable_directoryperdb'] = true
-default['mongodb']['config']['oplogSize'] = 5120
+default['mongodb']['config']['oplogSize'] = node['kernel']['machine'].index("x86_64") ? 5120 : 1000
 
 
 ## for mongos


### PR DESCRIPTION
Could not start mongodb on 32bit Ubuntu (http://files.vagrantup.com/precise32.box) with cookbok-defaults. 
The log suggested that oplogSize was too big for 32-bit system. This PR fixes it.