### PR TITLE
Fix for apt cookbook v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of mongodb-10gen.
 
+## 0.2.0
+
+* apt cookbook v2.5.0 doesn't provide apt-get update every run.
+* apt cookbook v2.5.0 does an immediate apt-get update after adding a repository
+
 ## 0.1.10
 
 * fix: #6 Error when using a base_dir different of /data/mongodb/ @mgrenonville

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,8 +4,8 @@ maintainer_email "sawanoboriyu@higanworks.com"
 license          "MIT"
 description      "Installs/Configures mongodb-10gen"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.10"
-depends          "apt"
+version          "0.2.0"
+depends          "apt", ">= 2.5.0"
 depends          "mongodb-10gen" # workaround for TravisCI
 supports         "ubuntu"
 supports         "debian"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,7 +37,6 @@ apt_repository "mongodb-10gen" do
   keyserver "keyserver.ubuntu.com"
   key "7F0CEB10"
   action :add
-  notifies :run, "execute[apt-get update]", :immediately  # recipe[apt::default]
 end
 
 


### PR DESCRIPTION
- apt cookbook v2.5.0 doesn't provide apt-get update every run.
- apt cookbook v2.5.0 does an immediate apt-get update after adding a repository
